### PR TITLE
Ensure that NSS packages are updated

### DIFF
--- a/roles/freeipa-setup/tasks/main.yml
+++ b/roles/freeipa-setup/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Ensure that NSS is updated
+  yum:
+    name: 'nss'
+    state: latest
+  become: yes
+
 - block:
   - name: Set FreeIPA admin password
     set_fact:


### PR DESCRIPTION
FreeIPA will not deploy correctly with the default CentOS 7 version
of NSS installed.